### PR TITLE
rename remnants of d6678d4 to singularize AuditLog collection

### DIFF
--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -59,8 +59,8 @@ describe("Plugin tests", () => {
   });
 
   it("audit logs collection is defined upon instantiation", () => {
-    expect(payload.collections["audit-logs"]).toBeDefined();
-    expect(payload.collections["audit-logs"].config).toBeDefined();
-    expect(payload.collections["audit-logs"].config.slug).toBeDefined();
+    expect(payload.collections["audit-log"]).toBeDefined();
+    expect(payload.collections["audit-log"].config).toBeDefined();
+    expect(payload.collections["audit-log"].config.slug).toBeDefined();
   });
 });

--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -69,7 +69,7 @@ export interface Config {
   collections: {
     posts: Post;
     media: Media;
-    'audit-logs': AuditLog;
+    'audit-log': AuditLog;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -79,7 +79,7 @@ export interface Config {
   collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
-    'audit-logs': AuditLogsSelect<false> | AuditLogsSelect<true>;
+    'audit-log': AuditLogSelect<false> | AuditLogSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -151,15 +151,16 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "audit-logs".
+ * via the `definition` "audit-log".
  */
 export interface AuditLog {
   id: string;
   timestamp: string;
-  user: string | User;
   operation: 'create' | 'read' | 'update' | 'delete';
   resourceType: string;
   documentId: string;
+  previousVersionId?: string | null;
+  user: string | User;
   updatedAt: string;
   createdAt: string;
 }
@@ -196,7 +197,7 @@ export interface PayloadLockedDocument {
         value: string | Media;
       } | null)
     | ({
-        relationTo: 'audit-logs';
+        relationTo: 'audit-log';
         value: string | AuditLog;
       } | null)
     | ({
@@ -273,14 +274,15 @@ export interface MediaSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "audit-logs_select".
+ * via the `definition` "audit-log_select".
  */
-export interface AuditLogsSelect<T extends boolean = true> {
+export interface AuditLogSelect<T extends boolean = true> {
   timestamp?: T;
-  user?: T;
   operation?: T;
   resourceType?: T;
   documentId?: T;
+  previousVersionId?: T;
+  user?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -2,10 +2,13 @@ import type { CollectionConfig } from "payload";
 
 import type { PayloadSentinelConfig } from "../config.js";
 
-type AuditLogsCollectionOptions = Required<Pick<PayloadSentinelConfig, "auditLogsCollection" | "authCollection">>;
+type AuditLogCollectionOptions = Required<Pick<PayloadSentinelConfig, "auditLogCollection" | "authCollection">>;
 
-export const AuditLog = ({ auditLogsCollection, authCollection }: AuditLogsCollectionOptions): CollectionConfig => ({
-  slug: auditLogsCollection,
+export const AuditLog = ({
+  auditLogCollection: auditLogCollection,
+  authCollection,
+}: AuditLogCollectionOptions): CollectionConfig => ({
+  slug: auditLogCollection,
   access: {
     create: () => false,
     delete: () => false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,10 +28,10 @@ export type CRUDOperations = {
 
 export type PayloadSentinelConfig = {
   /**
-   * The slug for the audit logs collection.
-   * @default 'audit-logs'
+   * The slug for the audit log collection.
+   * @default 'audit-log'
    */
-  auditLogsCollection?: string;
+  auditLogCollection?: string;
 
   /**
    * The collection slug for authentication/users.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -8,7 +8,7 @@ export const defaultCRUDOperations: CRUDOperations = {
 };
 
 export const defaultConfig: Required<PayloadSentinelConfig> = {
-  auditLogsCollection: "audit-logs",
+  auditLogCollection: "audit-log",
   authCollection: "users",
   disabled: false,
   excludedCollections: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export const payloadSentinel =
 
     // create and inject the audit logs collection
     const auditLogCollection = AuditLog({
-      auditLogsCollection: options.auditLogsCollection,
+      auditLogCollection: options.auditLogCollection,
       authCollection: options.authCollection,
     });
     config.collections.push(auditLogCollection);

--- a/src/injectHooks.spec.ts
+++ b/src/injectHooks.spec.ts
@@ -3,7 +3,7 @@ import type { BaseDatabaseAdapter, CollectionConfig, Config, GlobalConfig } from
 import { type HookOptions, injectAuditHooks } from "./injectHooks.js";
 
 const defaultTestOptions: HookOptions = {
-  auditLogsCollection: "audit-logs",
+  auditLogCollection: "audit-log",
   disabled: false,
   excludedCollections: [],
   excludedGlobals: [],
@@ -21,7 +21,7 @@ const mockCollection: CollectionConfig = {
 };
 
 const mockAuditLogCollection: CollectionConfig = {
-  slug: "audit-logs",
+  slug: "audit-log",
   fields: [],
 };
 
@@ -101,7 +101,7 @@ describe("injectAuditHooks", () => {
     const options = { ...defaultTestOptions };
     injectAuditHooks(mockConfig, options);
 
-    const targetCollection = mockConfig.collections?.find((c) => c.slug === "audit-logs");
+    const targetCollection = mockConfig.collections?.find((c) => c.slug === "audit-log");
     expect(targetCollection).toBeDefined();
     // check that no new hooks were added
     expect(targetCollection?.hooks?.afterChange).toBeUndefined();

--- a/src/injectHooks.ts
+++ b/src/injectHooks.ts
@@ -7,7 +7,7 @@ import { logCollectionAudit, logGlobalAudit } from "./logger.js";
 export type HookOptions = Required<
   Pick<
     PayloadSentinelConfig,
-    "auditLogsCollection" | "disabled" | "excludedCollections" | "excludedGlobals" | "operations"
+    "auditLogCollection" | "disabled" | "excludedCollections" | "excludedGlobals" | "operations"
   >
 >;
 
@@ -31,7 +31,7 @@ export const injectAuditHooks = (config: Config, options: HookOptions): void => 
   // add hooks to all collections that aren't explicitly excluded
   for (const collection of config.collections) {
     // skip excluded collections and the audit log collection itself
-    if (options.excludedCollections?.includes(collection.slug) || collection.slug === options.auditLogsCollection) {
+    if (options.excludedCollections?.includes(collection.slug) || collection.slug === options.auditLogCollection) {
       continue;
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import type { JsonObject, Operation, PayloadRequest, TypeWithID, TypeWithVersion
 
 import type { PayloadSentinelConfig } from "./config.js";
 
-type LogOptions = Required<Pick<PayloadSentinelConfig, "auditLogsCollection" | "disabled" | "operations">>;
+type LogOptions = Required<Pick<PayloadSentinelConfig, "auditLogCollection" | "disabled" | "operations">>;
 
 /**
  * Logs an audit entry for a collection operation.
@@ -60,7 +60,7 @@ export async function logCollectionAudit(
   }
   try {
     await req.payload.create({
-      collection: options.auditLogsCollection,
+      collection: options.auditLogCollection,
       data: {
         documentId: doc.id,
         operation,
@@ -124,7 +124,7 @@ export async function logGlobalAudit(
   }
   try {
     await req.payload.create({
-      collection: options.auditLogsCollection,
+      collection: options.auditLogCollection,
       data: {
         documentId: globalSlug,
         operation,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `audit-logs` to `audit-log` across the codebase for consistency.
> 
>   - **Renaming**:
>     - Rename `audit-logs` to `audit-log` in `dev/int.spec.ts`, `dev/payload-types.ts`, and `src/collections/AuditLog.ts`.
>     - Update `PayloadSentinelConfig` in `src/config.ts` and `src/defaults.ts` to use `auditLogCollection` instead of `auditLogsCollection`.
>     - Adjust `injectAuditHooks` in `src/injectHooks.ts` and `src/injectHooks.spec.ts` to reflect the singular form.
>     - Modify `logCollectionAudit` and `logGlobalAudit` in `src/logger.ts` to use `auditLogCollection`.
>   - **Behavior**:
>     - No functional changes; only renaming for consistency.
>     - Tests and configurations updated to match the new naming convention.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for ca4bf43b30cfce73fa47b2b9283fe7e96f64b350. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->