### PR TITLE
ci: add pre-commit hooks with husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+pnpm dev:generate-types
+git add dev/payload-types.ts
 pnpm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 pnpm dev:generate-types
 git add dev/payload-types.ts
 pnpm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+set -e
 pnpm dev:generate-types
 git add dev/payload-types.ts
 pnpm test

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "prepublishOnly": "pnpm clean && pnpm build",
     "test": "pnpm test:unit && pnpm test:int",
     "test:unit": "jest src/",
-    "test:int": "jest dev/"
+    "test:int": "jest dev/",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint": "^9.23.0",
     "eslint-config-next": "15.3.0",
     "graphql": "^16.8.1",
+    "husky": "^9.1.7",
     "jest": "29.7.0",
     "next": "15.3.0",
     "open": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.10.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@22.14.1)(babel-plugin-macros@3.1.0)
@@ -3378,6 +3381,11 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -9131,6 +9139,8 @@ snapshots:
       resolve-alpn: 1.2.1
 
   human-signals@2.1.0: {}
+
+  husky@9.1.7: {}
 
   ieee754@1.2.1: {}
 


### PR DESCRIPTION
- install husky and init husky project
- add `pnpm test` to pre-commit hook
- add payload type generation to pre-commit hook

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Husky pre-commit hooks to generate types and run tests before committing.
> 
>   - **Pre-commit Hooks**:
>     - Add `.husky/pre-commit` to run `pnpm dev:generate-types`, stage `dev/payload-types.ts`, and execute `pnpm test`.
>   - **Dependencies**:
>     - Add `husky` as a dev dependency in `package.json`.
>     - Add `prepare` script in `package.json` to initialize Husky.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for e264d4283ad0727c7a71dfc9aeac59625d05d4a3. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->