### PR TITLE
ui: add coloured operation cells

### DIFF
--- a/dev/app/(payload)/admin/importMap.js
+++ b/dev/app/(payload)/admin/importMap.js
@@ -1,3 +1,4 @@
+import { OperationCell as OperationCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { ResourceURLCell as ResourceURLCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { PreviousVersionIDCell as PreviousVersionIDCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -24,6 +25,7 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 
 export const importMap = {
+  "payload-sentinel/rsc#OperationCell": OperationCell_70fdd63a789def68db425ca993df4c54,
   "payload-sentinel/rsc#ResourceURLCell": ResourceURLCell_70fdd63a789def68db425ca993df4c54,
   "payload-sentinel/rsc#PreviousVersionIDCell": PreviousVersionIDCell_70fdd63a789def68db425ca993df4c54,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -32,7 +32,12 @@ export const AuditLog = ({
     {
       name: "operation",
       type: "select",
-      admin: { readOnly: true },
+      admin: {
+        components: {
+          Cell: "payload-sentinel/rsc#OperationCell",
+        },
+        readOnly: true,
+      },
       options: ["create", "read", "update", "delete"],
       required: true,
     },

--- a/src/components/OperationCell.module.css
+++ b/src/components/OperationCell.module.css
@@ -1,0 +1,39 @@
+.create {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: #00e135b0;
+  text-transform: capitalize;
+  border-radius: 4px;
+}
+
+.update {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: #ea841db0;
+  text-transform: capitalize;
+  border-radius: 4px;
+}
+
+.delete {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: #c60000b0;
+  text-transform: capitalize;
+  border-radius: 4px;
+}
+
+.read {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: hsla(211, 95%, 69%, 0.69);
+  text-transform: capitalize;
+  border-radius: 4px;
+}

--- a/src/components/OperationCell.tsx
+++ b/src/components/OperationCell.tsx
@@ -1,0 +1,21 @@
+import type { DefaultServerCellComponentProps, Operation } from "payload";
+
+import styles from "./OperationCell.module.css";
+
+export const OperationCell = (props: DefaultServerCellComponentProps) => {
+  const cellData: Operation = props.cellData;
+  if (!cellData) {
+    return <span>Invalid</span>;
+  }
+
+  switch (cellData) {
+    case "create":
+      return <span className={styles.create}>{cellData}</span>;
+    case "delete":
+      return <span className={styles.delete}>{cellData}</span>;
+    case "read":
+      return <span className={styles.read}>{cellData}</span>;
+    case "update":
+      return <span className={styles.update}>{cellData}</span>;
+  }
+};

--- a/src/exports/rsc.ts
+++ b/src/exports/rsc.ts
@@ -1,2 +1,3 @@
+export { OperationCell } from "../components/OperationCell.js";
 export { PreviousVersionIDCell } from "../components/PreviousVersionIDCell.js";
 export { ResourceURLCell } from "../components/ResourceURLCell.js";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `OperationCell` component to display colored operation types in the UI and integrate it into the audit log.
> 
>   - **UI Enhancements**:
>     - Added `OperationCell` component in `OperationCell.tsx` to display operation types (create, read, update, delete) with specific colors.
>     - Styles for `OperationCell` defined in `OperationCell.module.css`.
>   - **Integration**:
>     - Updated `AuditLog.ts` to use `OperationCell` for the `operation` field.
>     - Added `OperationCell` to `importMap.js` and `rsc.ts` for proper import and export handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for 2429e8f7c394a2317c8c8e2adc908dfb09252803. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->