### PR TITLE
fix(build): add main declaration to package.json for bundlephobia

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
       "default": "./src/exports/rsc.ts"
     }
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
fix for Bundlephobia's `EntryPointError` since it relies on main only instead of `publishConfig` 

see `https://github.com/pastelsky/bundlephobia/issues/379`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Bundlephobia `EntryPointError` by updating `main` and `types` in `package.json` to point to `dist` files.
> 
>   - **Behavior**:
>     - Fixes `EntryPointError` in Bundlephobia by changing `main` and `types` in `package.json` to point to `./dist/index.js` and `./dist/index.d.ts` respectively.
>   - **Misc**:
>     - Updates `main` and `types` fields in `package.json` to align with `publishConfig`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for f05a9f5124ba1af3a19e88e4483f541f17135151. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->