### PR TITLE
ci: add build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    timeout-minutes: 5
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build plugin
+        run: pnpm build
+
   unit_tests:
     timeout-minutes: 5
     runs-on: ubuntu-22.04


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a `build` job to the CI workflow in `.github/workflows/main.yml` to install dependencies and build the plugin.
> 
>   - **CI Workflow**:
>     - Adds a `build` job to `.github/workflows/main.yml`.
>     - The `build` job runs on `ubuntu-22.04` and has a timeout of 5 minutes.
>     - Steps include checking out the code, installing `pnpm`, setting up Node.js, installing dependencies, and building the plugin.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for 0876bc010509031ba9771625f66184730be06d30. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->