### PR TITLE
fix(build): exports should point to dist instead of src

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
         run: pnpm test:unit
 
   int_tests:
+    needs: build
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
@@ -77,6 +78,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build plugin
+        run: pnpm build
 
       - name: Run integration tests
         run: pnpm test:int

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
       - name: Build plugin
         run: pnpm build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
 
   unit_tests:
     timeout-minutes: 5
@@ -79,8 +85,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build plugin
-        run: pnpm build
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Run integration tests
         run: pnpm test:int
+
+      - name: Clean up build artifact
+        uses: geekyeggo/delete-artifact@e46cfb9575865f907c2beb2e4170b5f4c7d77c52
+        with:
+          name: dist
+          failOnError: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 concurrency:
   # <workflow_name>-<branch_name>-<true || commit_sha if branch is protected>
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_protected && github.sha || ''}}

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./client": {
-      "import": "./src/exports/client.ts",
-      "types": "./src/exports/client.ts",
-      "default": "./src/exports/client.ts"
+      "import": "./dist/exports/client.js",
+      "types": "./dist/exports/client.d.ts",
+      "default": "./dist/exports/client.js"
     },
     "./rsc": {
-      "import": "./src/exports/rsc.ts",
-      "types": "./src/exports/rsc.ts",
-      "default": "./src/exports/rsc.ts"
+      "import": "./dist/exports/rsc.js",
+      "types": "./dist/exports/rsc.d.ts",
+      "default": "./dist/exports/rsc.js"
     }
   },
   "main": "./dist/index.js",
@@ -97,27 +97,6 @@
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
     "pnpm": "^9 || ^10"
-  },
-  "publishConfig": {
-    "exports": {
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "./client": {
-        "import": "./dist/exports/client.js",
-        "types": "./dist/exports/client.d.ts",
-        "default": "./dist/exports/client.js"
-      },
-      "./rsc": {
-        "import": "./dist/exports/rsc.js",
-        "types": "./dist/exports/rsc.d.ts",
-        "default": "./dist/exports/rsc.js"
-      }
-    },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
need to export dist instead of src for npm registry. also remove `publishConfig` since it is now redundant (relevant: #15)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update build process to export from `dist` in `package.json` and adjust GitHub Actions workflow for artifact handling.
> 
>   - **Build Process**:
>     - Change `exports` in `package.json` to point to `dist` instead of `src` for npm registry compatibility.
>     - Remove `publishConfig` from `package.json` as it is now redundant.
>   - **GitHub Actions**:
>     - Add `permissions` to `main.yml` for content read access.
>     - Add steps to upload and download build artifacts in `main.yml` for integration tests.
>     - Add cleanup step for build artifacts in `main.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for 0ebcfe837be1ac1dffc5983826611d7cd21f74a0. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->