### PR TITLE
use native createdAt field for storing timestamp

### DIFF
--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -15,21 +15,12 @@ export const AuditLog = ({
     update: () => false,
   },
   admin: {
-    defaultColumns: ["timestamp", "operation", "resourceURL", "previousVersionId", "user"],
+    defaultColumns: ["createdAt", "operation", "resourceURL", "previousVersionId", "user"],
     disableCopyToLocale: true,
     group: "Payload Sentinel",
-    useAsTitle: "timestamp",
+    useAsTitle: "createdAt",
   },
   fields: [
-    {
-      name: "timestamp",
-      type: "date",
-      admin: {
-        date: { displayFormat: "yyyy-MM-dd HH:mm:ss" },
-        readOnly: true,
-      },
-      required: true,
-    },
     {
       name: "operation",
       type: "select",


### PR DESCRIPTION
prefer the native `createdAt` field for storing timestamp of each log instead of using a custom & redundant `timestamp` field
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace custom `timestamp` field with native `createdAt` in `AuditLog`.
> 
>   - **Behavior**:
>     - Replace `timestamp` field with native `createdAt` in `AuditLog`.
>     - Update `defaultColumns` and `useAsTitle` to use `createdAt` instead of `timestamp`.
>   - **Fields**:
>     - Remove `timestamp` field from `fields` array in `AuditLog`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for 60f11a7fbbf6a5e4caf5dc19b90e37fbef9f4bcb. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->