### PR TITLE
ci: generate import maps on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,6 @@
 set -e
 pnpm dev:generate-types
 git add dev/payload-types.ts
+pnpm dev:generate-importmap
+git add dev/app/\(payload\)/admin/importMap.js
 pnpm test


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates pre-commit hook to generate and stage import maps on commit.
> 
>   - **Pre-commit Hook**:
>     - Updates `.husky/pre-commit` to run `pnpm dev:generate-importmap` and add `dev/app/(payload)/admin/importMap.js` to git.
>     - Ensures import maps are generated and staged on commit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for d21f5f008f981f47d092d736eef6a579ce216c33. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->