### PR TITLE
fix: override createdAt log field and add dateFormat config option

### DIFF
--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -2,11 +2,14 @@ import type { CollectionConfig } from "payload";
 
 import type { PayloadSentinelConfig } from "../config.js";
 
-type AuditLogCollectionOptions = Required<Pick<PayloadSentinelConfig, "auditLogCollection" | "authCollection">>;
+type AuditLogCollectionOptions = Required<
+  Pick<PayloadSentinelConfig, "auditLogCollection" | "authCollection" | "dateFormat">
+>;
 
 export const AuditLog = ({
-  auditLogCollection: auditLogCollection,
+  auditLogCollection,
   authCollection,
+  dateFormat,
 }: AuditLogCollectionOptions): CollectionConfig => ({
   slug: auditLogCollection,
   access: {
@@ -21,6 +24,15 @@ export const AuditLog = ({
     useAsTitle: "createdAt",
   },
   fields: [
+    {
+      name: "createdAt",
+      type: "date",
+      admin: {
+        date: { displayFormat: dateFormat },
+        readOnly: true,
+      },
+      required: true,
+    },
     {
       name: "operation",
       type: "select",
@@ -37,9 +49,7 @@ export const AuditLog = ({
       name: "resourceURL",
       type: "text",
       admin: {
-        components: {
-          Cell: "payload-sentinel/rsc#ResourceURLCell",
-        },
+        components: { Cell: "payload-sentinel/rsc#ResourceURLCell" },
         readOnly: true,
       },
       label: "Resource URL",
@@ -56,9 +66,7 @@ export const AuditLog = ({
       name: "previousVersionId",
       type: "text",
       admin: {
-        components: {
-          Cell: "payload-sentinel/rsc#PreviousVersionIDCell",
-        },
+        components: { Cell: "payload-sentinel/rsc#PreviousVersionIDCell" },
         readOnly: true,
       },
       label: "Previous Version ID",

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,12 @@ export type PayloadSentinelConfig = {
   authCollection?: CollectionSlug;
 
   /**
+   * Represents the date format in which audit log timestamps should be displayed.
+   * Accepts any valid unicode date format: https://date-fns.org/v4.1.0/docs/format
+   */
+  dateFormat?: string;
+
+  /**
    * Whether to disable the audit logging functionality.
    * @default false
    */

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -10,6 +10,7 @@ export const defaultCRUDOperations: CRUDOperations = {
 export const defaultConfig: Required<PayloadSentinelConfig> = {
   auditLogCollection: "audit-log",
   authCollection: "users",
+  dateFormat: "EEE, dd MMM yyyy HH:mm:ss",
   disabled: false,
   excludedCollections: [],
   excludedGlobals: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export const payloadSentinel =
     const auditLogCollection = AuditLog({
       auditLogCollection: options.auditLogCollection,
       authCollection: options.authCollection,
+      dateFormat: options.dateFormat,
     });
     config.collections.push(auditLogCollection);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -87,6 +87,7 @@ export async function logCollectionAudit(
     await args.req.payload.create({
       collection: params.auditLogCollection,
       data: {
+        createdAt: new Date(),
         documentId: String(args.doc.id),
         operation: params.operation,
         previousVersionId: previousVersion?.id,
@@ -135,6 +136,7 @@ export async function logGlobalAudit(
     await args.req.payload.create({
       collection: params.auditLogCollection,
       data: {
+        createdAt: new Date(),
         documentId: args.global.slug,
         operation: params.operation,
         previousVersionId: previousVersion?.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `dateFormat` config option for audit logs and sets `createdAt` field in `AuditLog.ts` and `logger.ts`.
> 
>   - **Behavior**:
>     - Adds `dateFormat` option to `PayloadSentinelConfig` in `config.ts` for audit log timestamps.
>     - Overrides `createdAt` field in `AuditLog.ts` to use `dateFormat` and set as read-only.
>     - Sets `createdAt` to current date in `logCollectionAudit()` and `logGlobalAudit()` in `logger.ts`.
>   - **Defaults**:
>     - Sets default `dateFormat` to `"EEE, dd MMM yyyy HH:mm:ss"` in `defaults.ts`.
>   - **Misc**:
>     - Minor formatting changes in `AuditLog.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for 83159b05d43b3a7ba09735e1405528fd4e6ede3b. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->