### PR TITLE
feat: add config option for audit log read access

### DIFF
--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -25,7 +25,7 @@ dotenv.config({
 process.env.DISABLE_PAYLOAD_HMR = "true";
 process.env.PAYLOAD_DROP_DATABASE = "true";
 
-describe("Plugin tests with default config", () => {
+describe("plugin tests with default config", () => {
   let payload: Payload;
   let restClient: NextRESTClient;
 
@@ -46,174 +46,180 @@ describe("Plugin tests with default config", () => {
     }
   });
 
-  it("plugin is defined upon instantiation", async () => {
-    const { default: config } = await import("./payload.config.js");
-    const resolvedConfig = await config;
-    expect(resolvedConfig.plugins[0]).toBeDefined();
+  describe("instantiation", () => {
+    it("plugin is defined", async () => {
+      const { default: config } = await import("./payload.config.js");
+      const resolvedConfig = await config;
+      expect(resolvedConfig.plugins[0]).toBeDefined();
+    });
+
+    it("audit logs collection is injected", () => {
+      expect(payload.collections["audit-log"]).toBeDefined();
+      expect(payload.collections["audit-log"].config).toBeDefined();
+      expect(payload.collections["audit-log"].config.slug).toBe("audit-log");
+    });
   });
 
-  it("audit logs collection is injected", () => {
-    expect(payload.collections["audit-log"]).toBeDefined();
-    expect(payload.collections["audit-log"].config).toBeDefined();
-    expect(payload.collections["audit-log"].config.slug).toBe("audit-log");
-  });
+  describe("crud operations are logged", () => {
+    it("create collection", async () => {
+      try {
+        // get user to associate with the audit log
+        const user = await getUserFixture(payload);
 
-  it("create collection operation is logged", async () => {
-    try {
-      // get user to associate with the audit log
-      const user = await getUserFixture(payload);
+        // create arbitrary post
+        const createdDoc = await payload.create({
+          collection: "posts",
+          data: {
+            example: "jvgkjhsagdfds",
+          },
+          overrideAccess: false,
+          user,
+        });
 
-      // create arbitrary post
-      const createdDoc = await payload.create({
-        collection: "posts",
-        data: {
-          example: "jvgkjhsagdfds",
-        },
-        overrideAccess: false,
-        user,
-      });
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
 
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
+        // audit log should've been created
+        const logs = await payload.find({
+          collection: "audit-log",
+          limit: 1,
+          sort: "-createdAt",
+        });
 
-      // audit log should've been created
-      const logs = await payload.find({
-        collection: "audit-log",
-        limit: 1,
-        sort: "-createdAt",
-      });
+        expect(logs.totalDocs).toBeGreaterThan(0);
 
-      expect(logs.totalDocs).toBeGreaterThan(0);
+        const log = logs.docs[0];
+        expect(log.documentId).toStrictEqual(String(createdDoc.id));
+        expect(log.operation).toBe("create");
+      } finally {
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
+      }
+    });
 
-      const log = logs.docs[0];
-      expect(log.documentId).toStrictEqual(String(createdDoc.id));
-      expect(log.operation).toBe("create");
-    } finally {
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
-    }
-  });
+    it("update collection", async () => {
+      try {
+        // get user to associate with the audit log
+        const user = await getUserFixture(payload);
 
-  it("update collection operation is logged", async () => {
-    try {
-      // get user to associate with the audit log
-      const user = await getUserFixture(payload);
+        // get arbitrary post
+        const post = await getPostFixture(payload);
 
-      // get arbitrary post
-      const post = await getPostFixture(payload);
+        await payload.update({
+          id: post.id,
+          collection: "posts",
+          data: {
+            example: "TEST",
+          },
+          user,
+        });
 
-      await payload.update({
-        id: post.id,
-        collection: "posts",
-        data: {
-          example: "TEST",
-        },
-        user,
-      });
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
 
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
+        // audit log should've been created
+        const logs = await payload.find({
+          collection: "audit-log",
+          limit: 1,
+          sort: "-createdAt",
+        });
 
-      // audit log should've been created
-      const logs = await payload.find({
-        collection: "audit-log",
-        limit: 1,
-        sort: "-createdAt",
-      });
+        expect(logs.totalDocs).toBeGreaterThan(0);
 
-      expect(logs.totalDocs).toBeGreaterThan(0);
+        const log = logs.docs[0];
+        expect(log.documentId).toStrictEqual(String(post.id));
+        expect(log.operation).toBe("update");
+      } finally {
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
+      }
+    });
 
-      const log = logs.docs[0];
-      expect(log.documentId).toStrictEqual(String(post.id));
-      expect(log.operation).toBe("update");
-    } finally {
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
-    }
-  });
+    it("delete collection", async () => {
+      try {
+        // get user to associate with the audit log
+        const user = await getUserFixture(payload);
 
-  it("delete collection operation is logged", async () => {
-    try {
-      // get user to associate with the audit log
-      const user = await getUserFixture(payload);
+        // create arbitrary post
+        const post = await getPostFixture(payload);
 
-      // create arbitrary post
-      const post = await getPostFixture(payload);
+        // delete the post
+        await payload.delete({
+          id: post.id,
+          collection: "posts",
+          user,
+        });
 
-      // delete the post
-      await payload.delete({
-        id: post.id,
-        collection: "posts",
-        user,
-      });
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
 
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
+        // audit log should've been created
+        const logs = await payload.find({
+          collection: "audit-log",
+          limit: 1,
+          sort: "-createdAt",
+        });
 
-      // audit log should've been created
-      const logs = await payload.find({
-        collection: "audit-log",
-        limit: 1,
-        sort: "-createdAt",
-      });
+        expect(logs.totalDocs).toBeGreaterThan(0);
 
-      expect(logs.totalDocs).toBeGreaterThan(0);
+        const log = logs.docs[0];
+        expect(log.documentId).toStrictEqual(String(post.id));
+        expect(log.operation).toBe("delete");
+      } finally {
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
+      }
+    });
 
-      const log = logs.docs[0];
-      expect(log.documentId).toStrictEqual(String(post.id));
-      expect(log.operation).toBe("delete");
-    } finally {
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
-    }
-  });
+    it.todo("read collection");
 
-  it.todo("read collection operaton is logged");
+    it("update global", async () => {
+      try {
+        // get user to associate with the audit log
+        const user = await getUserFixture(payload);
 
-  it("update global operation is logged", async () => {
-    try {
-      // get user to associate with the audit log
-      const user = await getUserFixture(payload);
-
-      // update the existing 'settings' global
-      await payload.updateGlobal({
-        slug: "settings",
-        data: {
-          example: {
-            root: {
-              type: "root",
-              children: [
-                {
-                  type: "paragraph",
-                  children: [{ text: "woooooo" }],
-                },
-              ],
+        // update the existing 'settings' global
+        await payload.updateGlobal({
+          slug: "settings",
+          data: {
+            example: {
+              root: {
+                type: "root",
+                children: [
+                  {
+                    type: "paragraph",
+                    children: [{ text: "woooooo" }],
+                  },
+                ],
+              },
             },
           },
-        },
-        user,
-      });
+          user,
+        });
 
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
 
-      // audit log should've been created
-      const logs = await payload.find({
-        collection: "audit-log",
-        limit: 1,
-        sort: "-createdAt",
-      });
+        // audit log should've been created
+        const logs = await payload.find({
+          collection: "audit-log",
+          limit: 1,
+          sort: "-createdAt",
+        });
 
-      expect(logs.totalDocs).toBeGreaterThan(0);
+        expect(logs.totalDocs).toBeGreaterThan(0);
 
-      const log = logs.docs[0];
-      expect(log.documentId).toStrictEqual(String("settings"));
-      expect(log.operation).toBe("update");
-    } finally {
-      // wait for operations to complete
-      await new Promise((resolve) => process.nextTick(resolve));
-    }
+        const log = logs.docs[0];
+        expect(log.documentId).toStrictEqual(String("settings"));
+        expect(log.operation).toBe("update");
+      } finally {
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
+      }
+    });
+
+    it.todo("read global");
   });
 
-  it.todo("read global operation is logged");
+  it.todo("read access permission denies unauthorized users");
 });

--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -3,10 +3,11 @@ import type { CollectionConfig } from "payload";
 import type { PayloadSentinelConfig } from "../config.js";
 
 type AuditLogCollectionOptions = Required<
-  Pick<PayloadSentinelConfig, "auditLogCollection" | "authCollection" | "dateFormat">
+  Pick<PayloadSentinelConfig, "access" | "auditLogCollection" | "authCollection" | "dateFormat">
 >;
 
 export const AuditLog = ({
+  access,
   auditLogCollection,
   authCollection,
   dateFormat,
@@ -15,6 +16,7 @@ export const AuditLog = ({
   access: {
     create: () => false,
     delete: () => false,
+    read: access,
     update: () => false,
   },
   admin: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, GlobalSlug } from "payload";
+import type { Access, CollectionSlug, GlobalSlug } from "payload";
 
 export type CRUDOperations = {
   /**
@@ -27,6 +27,13 @@ export type CRUDOperations = {
 };
 
 export type PayloadSentinelConfig = {
+  /**
+   * Read access for the audit log.
+   * Note: create, update, and delete access cannot be configured and are all denied.
+   * @default '({ req: { user } }) => { return Boolean(user)}'
+   */
+  access?: Access;
+
   /**
    * The slug for the audit log collection.
    * @default 'audit-log'

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -8,6 +8,9 @@ export const defaultCRUDOperations: CRUDOperations = {
 };
 
 export const defaultConfig: Required<PayloadSentinelConfig> = {
+  access: ({ req: { user } }) => {
+    return Boolean(user);
+  },
   auditLogCollection: "audit-log",
   authCollection: "users",
   dateFormat: "EEE, dd MMM yyyy HH:mm:ss",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export const payloadSentinel =
 
     // create and inject the audit logs collection
     const auditLogCollection = AuditLog({
+      access: options.access,
       auditLogCollection: options.auditLogCollection,
       authCollection: options.authCollection,
       dateFormat: options.dateFormat,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds configurable read access for audit logs and refactors tests to include read access scenarios.
> 
>   - **Behavior**:
>     - Adds `access` option to `PayloadSentinelConfig` in `config.ts` for configuring read access to the audit log.
>     - Updates `AuditLog` in `AuditLog.ts` to use the new `access` configuration for read access.
>     - Sets default `access` to allow read access if a user is present in `defaults.ts`.
>   - **Tests**:
>     - Refactors tests in `int.spec.ts` to group by instantiation and CRUD operations.
>     - Adds `it.todo` for "read collection" and "read global" operations in `int.spec.ts`.
>     - Adds `it.todo` for "read access permission denies unauthorized users" in `int.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for d25ef92dca7061efff85d85f95bec6451b62f6cf. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->