### PR TITLE
build: increase independence of tsconfigs

### DIFF
--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -155,14 +155,13 @@ export interface Media {
  */
 export interface AuditLog {
   id: number;
-  timestamp: string;
+  createdAt: string;
   operation: 'create' | 'read' | 'update' | 'delete';
   resourceURL: string;
   documentId: string;
   previousVersionId?: string | null;
   user?: (number | null) | User;
   updatedAt: string;
-  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -277,14 +276,13 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "audit-log_select".
  */
 export interface AuditLogSelect<T extends boolean = true> {
-  timestamp?: T;
+  createdAt?: T;
   operation?: T;
   resourceURL?: T;
   documentId?: T;
   previousVersionId?: T;
   user?: T;
   updatedAt?: T;
-  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -1,6 +1,15 @@
 {
-  "extends": "../tsconfig.json",
-  "exclude": [],
+  "extends": "../src/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "noEmit": true,
+    "paths": {
+      "@payload-config": ["./payload.config.ts"],
+      "payload-sentinel": ["../src/index.ts"],
+      "payload-sentinel/client": ["../src/exports/client.ts"],
+      "payload-sentinel/rsc": ["../src/exports/rsc.ts"]
+    }
+  },
   "include": [
     "**/*.js",
     "**/*.jsx",
@@ -12,16 +21,5 @@
     "../src/**/*.tsx",
     "next.config.mjs",
     ".next/types/**/*.ts"
-  ],
-  "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@payload-config": ["./payload.config.ts"],
-      "payload-sentinel": ["../src/index.ts"],
-      "payload-sentinel/client": ["../src/exports/client.ts"],
-      "payload-sentinel/rsc": ["../src/exports/rsc.ts"]
-    },
-    "noEmit": true,
-    "emitDeclarationOnly": false
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:types && pnpm build:swc",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
-    "build:types": "tsc --outDir dist --rootDir ./src",
+    "build:types": "tsc -p src/tsconfig.json --outDir dist",
     "clean": "rimraf {dist,*.tsbuildinfo}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "dev": "payload run ./dev/server.ts",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -22,5 +22,5 @@
       }
     ]
   },
-  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./dev/next-env.d.ts", "vitest.config.ts"]
+  "include": ["./**/*.ts", "./**/*.tsx"]
 }


### PR DESCRIPTION



move root tsconfig to src/tsconfig, note that dev/tsconfig still extends from src/tsconfig so do not assume full independence


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance TypeScript build independence and update `AuditLog` interface in `dev/payload-types.ts` for consistency.
> 
>   - **Build Configuration**:
>     - Updated `build:types` script in `package.json` to use `tsc -p src/tsconfig.json --outDir dist` for more independent TypeScript configuration.
>   - **TypeScript Interfaces**:
>     - In `dev/payload-types.ts`, renamed `timestamp` to `createdAt` in `AuditLog` and `AuditLogSelect` interfaces for consistency.
>     - Removed duplicate `createdAt` field in `AuditLog` and `AuditLogSelect` interfaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for eb4a0e20c17937d6a7cbf613d8c8d3b5e71feab1. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->