### PR TITLE
feat: add audit log collection group configuration option

### DIFF
--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -3,12 +3,13 @@ import type { CollectionConfig } from "payload";
 import type { PayloadSentinelConfig } from "../config.js";
 
 type AuditLogCollectionOptions = Required<
-  Pick<PayloadSentinelConfig, "access" | "auditLogCollection" | "authCollection" | "dateFormat">
+  Pick<PayloadSentinelConfig, "access" | "auditLogCollection" | "auditLogCollectionGroup" | "authCollection" | "dateFormat">
 >;
 
 export const AuditLog = ({
   access,
   auditLogCollection,
+  auditLogCollectionGroup,
   authCollection,
   dateFormat,
 }: AuditLogCollectionOptions): CollectionConfig => ({
@@ -22,7 +23,7 @@ export const AuditLog = ({
   admin: {
     defaultColumns: ["createdAt", "operation", "resourceURL", "previousVersionId", "user"],
     disableCopyToLocale: true,
-    group: "Payload Sentinel",
+    group: auditLogCollectionGroup,
     useAsTitle: "createdAt",
   },
   fields: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,12 @@ export type PayloadSentinelConfig = {
   auditLogCollection?: string;
 
   /**
+   * The group for the audit log collection.
+   * @default 'Payload Sentinal'
+   */
+  auditLogCollectionGroup?: string;
+
+  /**
    * The collection slug for authentication/users.
    * This collection will be used to associate audit log entries with users.
    * @default 'users'

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -12,6 +12,7 @@ export const defaultConfig: Required<PayloadSentinelConfig> = {
     return Boolean(user);
   },
   auditLogCollection: "audit-log",
+  auditLogCollectionGroup: "Payload Sentinal",
   authCollection: "users",
   dateFormat: "EEE, dd MMM yyyy HH:mm:ss",
   disabled: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export const payloadSentinel =
     const auditLogCollection = AuditLog({
       access: options.access,
       auditLogCollection: options.auditLogCollection,
+      auditLogCollectionGroup: options.auditLogCollectionGroup,
       authCollection: options.authCollection,
       dateFormat: options.dateFormat,
     });


### PR DESCRIPTION
This is an awesome plugin, i've been hoping for something like this it is super helpful. It would be nice though to be able to customize the collection group in the config as I personally have a number of other "Utility" collections and would like the audit log collection to be in the same "Utility" folder group in the sidebar. Would you consider this PR to add this functionality? Thank you!