### PR TITLE
ci(husky): build plugin on precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,5 @@ pnpm dev:generate-types
 git add dev/payload-types.ts
 pnpm dev:generate-importmap
 git add dev/app/\(payload\)/admin/importMap.js
+pnpm build
 pnpm test


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `pnpm build` to `.husky/pre-commit` to ensure the plugin is built before committing.
> 
>   - **Pre-commit Hook**:
>     - Adds `pnpm build` to `.husky/pre-commit` to ensure the plugin is built before committing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fpayload-sentinel&utm_source=github&utm_medium=referral)<sup> for 97e3a1dd9445c482ecabccefe2f124febdf4c61c. You can [customize](https://app.ellipsis.dev/atlasgong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->