### PR TITLE
fix: use tsx to run dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build:types": "tsc -p src/tsconfig.json --outDir dist",
     "clean": "rimraf {dist,*.tsbuildinfo}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
-    "dev": "payload run ./dev/server.ts",
+    "dev": "tsx dev/server.ts",
     "dev:generate-importmap": "pnpm dev:payload generate:importmap",
     "dev:generate-types": "pnpm dev:payload generate:types",
     "dev:payload": "cross-env PAYLOAD_CONFIG_PATH=./dev/payload.config.ts payload",


### PR DESCRIPTION
With `payload run` (which is designed for one-shot scripts), when `server.ts` finishes its top-level code, `bin()` calls `process.exit(0)`.

I suppose said call might've been added in a recent update, but an easy fix is just to run the server with `tsx`.