### PR TITLE
fix: differentiate between actor types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Payload Sentinel works without any configuration. If you want to customize its b
 
 - [ ] Analytics panel for usage insights
 - [ ] I18n support
-- [ ] Logging console (API) operations
+- [x] Logging console (API) operations
 - [ ] Seamless native integration with version diffs
 - [ ] Tamper-evident audit logs using cryptographic hash chaining
 

--- a/dev/app/(payload)/admin/importMap.js
+++ b/dev/app/(payload)/admin/importMap.js
@@ -1,6 +1,7 @@
 import { OperationCell as OperationCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { ResourceURLCell as ResourceURLCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { PreviousVersionIDCell as PreviousVersionIDCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
+import { ActorTypeCell as ActorTypeCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -30,6 +31,7 @@ export const importMap = {
   "payload-sentinel/rsc#OperationCell": OperationCell_70fdd63a789def68db425ca993df4c54,
   "payload-sentinel/rsc#ResourceURLCell": ResourceURLCell_70fdd63a789def68db425ca993df4c54,
   "payload-sentinel/rsc#PreviousVersionIDCell": PreviousVersionIDCell_70fdd63a789def68db425ca993df4c54,
+  "payload-sentinel/rsc#ActorTypeCell": ActorTypeCell_70fdd63a789def68db425ca993df4c54,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/dev/app/system-create/route.ts
+++ b/dev/app/system-create/route.ts
@@ -1,0 +1,17 @@
+import configPromise from "@payload-config";
+import { getPayload } from "payload";
+
+export const GET = async () => {
+  const payload = await getPayload({
+    config: configPromise,
+  });
+
+  await payload.create({
+    collection: "posts",
+    data: {
+      example: "system created post",
+    },
+  });
+
+  return Response.json({ status: "ok" });
+};

--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -60,7 +60,7 @@ describe("plugin tests with default config", () => {
     });
   });
 
-  describe("crud operations are logged", () => {
+  describe("user crud operations are logged", () => {
     it("create collection", async () => {
       try {
         // get user to associate with the audit log
@@ -91,6 +91,7 @@ describe("plugin tests with default config", () => {
         const log = logs.docs[0];
         expect(log.documentId).toStrictEqual(String(createdDoc.id));
         expect(log.operation).toBe("create");
+        expect(log.actorType).toBe("user");
       } finally {
         // wait for operations to complete
         await new Promise((resolve) => process.nextTick(resolve));
@@ -129,6 +130,7 @@ describe("plugin tests with default config", () => {
         const log = logs.docs[0];
         expect(log.documentId).toStrictEqual(String(post.id));
         expect(log.operation).toBe("update");
+        expect(log.actorType).toBe("user");
       } finally {
         // wait for operations to complete
         await new Promise((resolve) => process.nextTick(resolve));
@@ -165,6 +167,7 @@ describe("plugin tests with default config", () => {
         const log = logs.docs[0];
         expect(log.documentId).toStrictEqual(String(post.id));
         expect(log.operation).toBe("delete");
+        expect(log.actorType).toBe("user");
       } finally {
         // wait for operations to complete
         await new Promise((resolve) => process.nextTick(resolve));
@@ -212,6 +215,7 @@ describe("plugin tests with default config", () => {
         const log = logs.docs[0];
         expect(log.documentId).toStrictEqual(String("settings"));
         expect(log.operation).toBe("update");
+        expect(log.actorType).toBe("user");
       } finally {
         // wait for operations to complete
         await new Promise((resolve) => process.nextTick(resolve));
@@ -219,6 +223,40 @@ describe("plugin tests with default config", () => {
     });
 
     it.todo("read global");
+  });
+
+  describe("system operations are logged with system as actor", () => {
+    it("create collection", async () => {
+      try {
+        // create arbitrary post
+        const createdDoc = await payload.create({
+          collection: "posts",
+          data: {
+            example: "jvgkjhsagdfds",
+          },
+        });
+
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        // audit log should've been created
+        const logs = await payload.find({
+          collection: "audit-log",
+          limit: 1,
+          sort: "-createdAt",
+        });
+
+        expect(logs.totalDocs).toBeGreaterThan(0);
+
+        const log = logs.docs[0];
+        expect(log.documentId).toStrictEqual(String(createdDoc.id));
+        expect(log.operation).toBe("create");
+        expect(log.actorType).toBe("system");
+      } finally {
+        // wait for operations to complete
+        await new Promise((resolve) => process.nextTick(resolve));
+      }
+    });
   });
 
   it.todo("read access permission denies unauthorized users");

--- a/dev/next-env.d.ts
+++ b/dev/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -164,6 +164,7 @@ export interface AuditLog {
   resourceURL: string;
   documentId: string;
   previousVersionId?: string | null;
+  actorType: 'user' | 'system' | 'api';
   user?: (number | null) | User;
   updatedAt: string;
 }
@@ -310,6 +311,7 @@ export interface AuditLogSelect<T extends boolean = true> {
   resourceURL?: T;
   documentId?: T;
   previousVersionId?: T;
+  actorType?: T;
   user?: T;
   updatedAt?: T;
 }

--- a/src/collections/AuditLog.ts
+++ b/src/collections/AuditLog.ts
@@ -3,7 +3,10 @@ import type { CollectionConfig } from "payload";
 import type { PayloadSentinelConfig } from "../config.js";
 
 type AuditLogCollectionOptions = Required<
-  Pick<PayloadSentinelConfig, "access" | "auditLogCollection" | "auditLogCollectionGroup" | "authCollection" | "dateFormat">
+  Pick<
+    PayloadSentinelConfig,
+    "access" | "auditLogCollection" | "auditLogCollectionGroup" | "authCollection" | "dateFormat"
+  >
 >;
 
 export const AuditLog = ({
@@ -21,7 +24,7 @@ export const AuditLog = ({
     update: () => false,
   },
   admin: {
-    defaultColumns: ["createdAt", "operation", "resourceURL", "previousVersionId", "user"],
+    defaultColumns: ["createdAt", "operation", "resourceURL", "previousVersionId", "actorType", "user"],
     disableCopyToLocale: true,
     group: auditLogCollectionGroup,
     useAsTitle: "createdAt",
@@ -74,6 +77,16 @@ export const AuditLog = ({
       },
       label: "Previous Version ID",
       required: false,
+    },
+    {
+      name: "actorType",
+      type: "select",
+      admin: {
+        components: { Cell: "payload-sentinel/rsc#ActorTypeCell" },
+        readOnly: true,
+      },
+      options: ["user", "system", "api"],
+      required: true,
     },
     {
       name: "user",

--- a/src/components/ActorTypeCell.module.css
+++ b/src/components/ActorTypeCell.module.css
@@ -1,0 +1,39 @@
+.user {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: hsla(211, 95%, 69%, 0.69);
+  text-transform: capitalize;
+  border-radius: 4px;
+}
+
+.system {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: hsla(270, 50%, 60%, 0.7);
+  text-transform: capitalize;
+  border-radius: 4px;
+}
+
+.api {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: hsla(45, 90%, 45%, 0.85);
+  text-transform: capitalize;
+  border-radius: 4px;
+}
+
+.unknown {
+  display: inline-block;
+  padding: 4px 8px;
+  color: #ffffff;
+  text-align: center;
+  background: hsla(0, 0%, 55%, 0.7);
+  text-transform: capitalize;
+  border-radius: 4px;
+}

--- a/src/components/ActorTypeCell.tsx
+++ b/src/components/ActorTypeCell.tsx
@@ -1,0 +1,20 @@
+import type { DefaultServerCellComponentProps } from "payload";
+
+import styles from "./ActorTypeCell.module.css";
+
+type ActorType = "api" | "system" | "user";
+
+export const ActorTypeCell = (props: DefaultServerCellComponentProps) => {
+  const actorType: ActorType | null = props.cellData;
+
+  switch (actorType) {
+    case "api":
+      return <span className={styles.api}>API</span>;
+    case "system":
+      return <span className={styles.system}>System</span>;
+    case "user":
+      return <span className={styles.user}>User</span>;
+    default:
+      return <span className={styles.unknown}>Unknown</span>;
+  }
+};

--- a/src/exports/rsc.ts
+++ b/src/exports/rsc.ts
@@ -1,3 +1,4 @@
+export { ActorTypeCell } from "../components/ActorTypeCell.js";
 export { OperationCell } from "../components/OperationCell.js";
 export { PreviousVersionIDCell } from "../components/PreviousVersionIDCell.js";
 export { ResourceURLCell } from "../components/ResourceURLCell.js";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -47,6 +47,16 @@ interface GlobalLogInformationParams {
   operation: Operation;
 }
 
+function resolveActorType(req: PayloadRequest): "api" | "system" | "user" {
+  if (req.user?.id) {
+    return "user";
+  }
+  if (req.payloadAPI === "local") {
+    return "system";
+  }
+  return "api";
+}
+
 /**
  * Logs an audit entry for a collection operation.
  *
@@ -87,6 +97,7 @@ export async function logCollectionAudit(
     await args.req.payload.create({
       collection: params.auditLogCollection,
       data: {
+        actorType: resolveActorType(args.req),
         createdAt: new Date(),
         documentId: String(args.doc.id),
         operation: params.operation,
@@ -136,6 +147,7 @@ export async function logGlobalAudit(
     await args.req.payload.create({
       collection: params.auditLogCollection,
       data: {
+        actorType: resolveActorType(args.req),
         createdAt: new Date(),
         documentId: args.global.slug,
         operation: params.operation,


### PR DESCRIPTION
Audit logs previously had no way to distinguish between a user action, internal system action (e.g. requests made via Payload's [Local API](https://payloadcms.com/docs/local-api/overview)), and unauthenticated external API requests (e.g. Payload's [REST API](https://payloadcms.com/docs/rest-api/overview) or [GraphQL](https://payloadcms.com/docs/graphql/overview)). If no user was attached to the request, the user field would be null. 

This PR:
- adds `actorType` field (takes values `user`, `system`, and `api`) to the audit log collection schema
- resolves the actor type at audit log write time using `req.payloadAPI` and `req.user`
  - local API with no user -> system
  - unauthenticated REST/GraphQL -> api
  - authenticated -> user
- updates integration test suite to cover user and system actor types

This is a breaking change, so a migration is required. More details to follow in the upcoming release notes for 0.3.0.