### PR TITLE
chore: remove extraneous timestamp field

### DIFF
--- a/dev/app/(payload)/admin/importMap.js
+++ b/dev/app/(payload)/admin/importMap.js
@@ -1,6 +1,7 @@
 import { OperationCell as OperationCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { ResourceURLCell as ResourceURLCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { PreviousVersionIDCell as PreviousVersionIDCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
+import { ActorTypeCell as ActorTypeCell_70fdd63a789def68db425ca993df4c54 } from 'payload-sentinel/rsc'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -30,6 +31,7 @@ export const importMap = {
   "payload-sentinel/rsc#OperationCell": OperationCell_70fdd63a789def68db425ca993df4c54,
   "payload-sentinel/rsc#ResourceURLCell": ResourceURLCell_70fdd63a789def68db425ca993df4c54,
   "payload-sentinel/rsc#PreviousVersionIDCell": PreviousVersionIDCell_70fdd63a789def68db425ca993df4c54,
+  "payload-sentinel/rsc#ActorTypeCell": ActorTypeCell_70fdd63a789def68db425ca993df4c54,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -164,6 +164,7 @@ export interface AuditLog {
   resourceURL: string;
   documentId: string;
   previousVersionId?: string | null;
+  actorType: 'user' | 'system' | 'api';
   user?: (number | null) | User;
   updatedAt: string;
 }
@@ -310,6 +311,7 @@ export interface AuditLogSelect<T extends boolean = true> {
   resourceURL?: T;
   documentId?: T;
   previousVersionId?: T;
+  actorType?: T;
   user?: T;
   updatedAt?: T;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -92,7 +92,6 @@ export async function logCollectionAudit(
         operation: params.operation,
         previousVersionId: previousVersion?.id,
         resourceURL: "collections/" + args.collection.slug + "/" + String(args.doc.id),
-        timestamp: new Date(),
         user: args.req.user?.id,
       },
     });
@@ -141,7 +140,6 @@ export async function logGlobalAudit(
         operation: params.operation,
         previousVersionId: previousVersion?.id,
         resourceURL: "globals/" + args.global.slug,
-        timestamp: new Date(),
         user: args.req.user?.id,
       },
     });


### PR DESCRIPTION
this field doesn't exist in the audit log collection schema; so I assume currently payload is silently dropping it on every write. removing it since the existing `createdAt` field seems to cover whatever this field was intended for